### PR TITLE
Add generateParquetBuffer utility and fix multi-page encoding/decoding

### DIFF
--- a/src/bufferWriter.ts
+++ b/src/bufferWriter.ts
@@ -23,50 +23,37 @@ export interface ParquetBufferWriterOptions {
 
 /**
  * Synchronous in-memory Parquet writer that accumulates rows and returns a Buffer.
- * Browser-safe: no imports from stream, fs, or zlib.
  */
-export class ParquetBufferWriter<T> {
+export class ParquetBufferWriter<T = unknown> {
   private schema: ParquetSchema;
   private opts: ParquetBufferWriterOptions;
-  private chunks: Buffer[];
-  private offset: number;
-  private rowBuffer: ParquetWriteBuffer;
-  private rowGroups: RowGroup[];
-  private rowCount: number;
-  private closed: boolean;
-  private headerWritten: boolean;
   private rowGroupSize: number;
   private pageSize: number;
+  private rowCount: number = 0;
+  private rowBuffer: ParquetWriteBuffer;
+  private rowGroups: RowGroup[] = [];
+  private chunks: Buffer[] = [];
+  private offset: number = 0;
+  private headerWritten: boolean = false;
+  private closed: boolean = false;
+
+  constructor(schema: ParquetSchema, opts?: ParquetBufferWriterOptions) {
+    this.schema = schema;
+    this.opts = opts || {};
+    this.rowGroupSize = opts?.rowGroupSize || PARQUET_DEFAULT_ROW_GROUP_SIZE;
+    this.pageSize = opts?.pageSize || PARQUET_DEFAULT_PAGE_SIZE;
+    this.rowBuffer = new ParquetWriteBuffer(this.schema);
+  }
 
   /**
-   * Create a new ParquetBufferWriter
+   * Create a new ParquetBufferWriter and return it.
    */
-  static openBuffer<T>(
-    schema: ParquetSchema,
-    opts?: ParquetBufferWriterOptions
-  ): ParquetBufferWriter<T> {
+  static openBuffer<T = unknown>(schema: ParquetSchema, opts?: ParquetBufferWriterOptions): ParquetBufferWriter<T> {
     return new ParquetBufferWriter<T>(schema, opts);
   }
 
   /**
-   * Constructor
-   */
-  constructor(schema: ParquetSchema, opts?: ParquetBufferWriterOptions) {
-    this.schema = schema;
-    this.opts = opts || {};
-    this.chunks = [];
-    this.offset = 0;
-    this.rowBuffer = new ParquetWriteBuffer(schema);
-    this.rowGroups = [];
-    this.rowCount = 0;
-    this.closed = false;
-    this.headerWritten = false;
-    this.rowGroupSize = this.opts.rowGroupSize || PARQUET_DEFAULT_ROW_GROUP_SIZE;
-    this.pageSize = this.opts.pageSize || PARQUET_DEFAULT_PAGE_SIZE;
-  }
-
-  /**
-   * Append a row to the buffer. Synchronous.
+   * Append a row to the buffer.
    */
   appendRow(row: T): void {
     if (this.closed) {
@@ -143,4 +130,20 @@ export class ParquetBufferWriter<T> {
     // Reset row buffer for next row group
     this.rowBuffer = new ParquetWriteBuffer(this.schema);
   }
+}
+
+/**
+ * Convenience function: write an array of rows to a Parquet buffer.
+ * Equivalent to creating a ParquetBufferWriter, appending all rows, and calling toBuffer().
+ */
+export function generateParquetBuffer<T>(
+  schema: ParquetSchema,
+  rows: T[],
+  opts?: ParquetBufferWriterOptions
+): Buffer {
+  const writer = new ParquetBufferWriter<T>(schema, opts);
+  for (const row of rows) {
+    writer.appendRow(row);
+  }
+  return writer.toBuffer();
 }

--- a/src/codec/plain.ts
+++ b/src/codec/plain.ts
@@ -119,7 +119,7 @@ function encodeValues_INT32(values: ParquetValueArray): Buffer {
  */
 function decodeValues_INT32(cursor: CursorBuffer, count: number): Int32Array {
   const values =
-    systemIsLittleEndian && cursor.offset % 4 === 0
+    systemIsLittleEndian && (cursor.buffer.byteOffset + cursor.offset) % 4 === 0
       ? // On little-endian systems we can just use the data as-is
         new Int32Array(cursor.buffer.buffer, cursor.buffer.byteOffset + cursor.offset, count)
       : // Otherwise we have to copy and convert the data
@@ -215,7 +215,7 @@ function encodeValues_FLOAT(values: ParquetValueArray): Buffer {
  */
 function decodeValues_FLOAT(cursor: CursorBuffer, count: number): Float32Array {
   const values =
-    systemIsLittleEndian && cursor.offset % 4 === 0
+    systemIsLittleEndian && (cursor.buffer.byteOffset + cursor.offset) % 4 === 0
       ? // On little-endian systems with 4-byte aligned data we can avoid data copying
         new Float32Array(cursor.buffer.buffer, cursor.buffer.byteOffset + cursor.offset, count)
       : // Otherwise we have to copy and convert the data
@@ -253,7 +253,7 @@ function decodeValues_DOUBLE(
   count: number
 ): Float64Array {
   const values =
-    systemIsLittleEndian && cursor.offset % 8 === 0
+    systemIsLittleEndian && (cursor.buffer.byteOffset + cursor.offset) % 8 === 0
       ? // On little-endian systems with 8-byte aligned data we can avoid data copying
         new Float64Array(cursor.buffer.buffer, cursor.buffer.byteOffset + cursor.offset, count)
       : // Otherwise we have to copy and convert the data

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -252,23 +252,63 @@ function encodeColumnChunk(
   const data = buffer.columnData[column.path.join()];
   const stats = buffer.statistics[column.path.join()];
   const baseOffset = (opts.baseOffset || 0) + offset;
-  let pageBuf: Buffer;
+  const pageSize = opts.pageSize || PARQUET_DEFAULT_PAGE_SIZE;
+  const pageBuffers: Buffer[] = [];
   let total_uncompressed_size = 0;
   let total_compressed_size = 0;
-  {
-    let result: any;
-    if (opts.useDataPageV2) {
-      result = encodeDataPageV2(column, data, buffer.rowCount);
-    } else {
-      result = encodeDataPage(column, data);
-    }
-    pageBuf = result.page;
+
+  const encodePage = (pageData: ParquetWriteColumnData, rowCount: number) => {
+    const result = opts.useDataPageV2
+      ? encodeDataPageV2(column, pageData, rowCount)
+      : encodeDataPage(column, pageData);
+
+    pageBuffers.push(result.page);
     total_uncompressed_size +=
       result.header.uncompressed_page_size + result.headerSize;
     total_compressed_size +=
       result.header.compressed_page_size + result.headerSize;
+  };
+
+  if (data.count <= pageSize) {
+    encodePage(data, buffer.rowCount);
+  } else {
+    let valueOffset = 0;
+    let start = 0;
+
+    while (start < data.count) {
+      let end = Math.min(start + pageSize, data.count);
+      if (column.rLevelMax > 0 && end < data.count) {
+        while (end < data.count && data.rLevels[end] !== 0) {
+          end += 1;
+        }
+      }
+
+      const dLevels = data.dLevels.slice(start, end);
+      const rLevels = data.rLevels.slice(start, end);
+      let valueCount = 0;
+      for (const dLevel of dLevels) {
+        if (dLevel === column.dLevelMax) {
+          valueCount += 1;
+        }
+      }
+
+      const pageData: ParquetWriteColumnData = {
+        dLevels,
+        rLevels,
+        values: data.values.slice(valueOffset, valueOffset + valueCount),
+        count: end - start,
+      };
+
+      valueOffset += valueCount;
+      const pageRowCount = column.rLevelMax > 0
+        ? pageData.rLevels.filter(r => r === 0).length
+        : pageData.count;
+      encodePage(pageData, pageRowCount);
+      start = end;
+    }
   }
 
+  const pageBuf = Buffer.concat(pageBuffers);
   const metadata = new ColumnMetaData({
     path_in_schema: column.path,
     num_values: data.count,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,6 @@ export {
 export {
   ParquetBufferWriter,
   ParquetBufferWriterOptions,
+  generateParquetBuffer,
 } from './bufferWriter';
 export { ParquetShredder };

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -771,7 +771,8 @@ function decodeColumnChunk(
     colChunk.meta_data.codec
   ) as any;
 
-  return decodeDataPages(pagesBuf, field, compression);
+  const numValues = +colChunk.meta_data.num_values;
+  return decodeDataPages(pagesBuf, field, compression, numValues);
 }
 
 /**
@@ -793,7 +794,8 @@ function decodeValues(
 function decodeDataPages(
   buffer: Buffer,
   column: ParquetField,
-  compression: ParquetCompression
+  compression: ParquetCompression,
+  numValues?: number
 ): ParquetReadData {
   const cursor: CursorBuffer = {
     buffer,
@@ -807,10 +809,16 @@ function decodeDataPages(
   let count = 0;
 
   while (cursor.offset < cursor.size) {
+    // Stop once we have decoded all expected values (guards against trailing
+    // bytes from dictionary pages being included in total_compressed_size).
+    if (numValues !== undefined && count >= numValues) {
+      break;
+    }
+
     // const pageHeader = new parquet_thrift.PageHeader();
     // cursor.offset += parquet_util.decodeThrift(pageHeader, cursor.buffer);
 
-    const { pageHeader, length } = Util.decodePageHeader(cursor.buffer);
+    const { pageHeader, length } = Util.decodePageHeader(cursor.buffer, cursor.offset);
     cursor.offset += length;
 
     const pageType = Util.getThriftEnum(PageType, pageHeader.type);
@@ -819,10 +827,19 @@ function decodeDataPages(
       throw new Error(`Unsupported data page type ${pageType}`);
     }
 
+    // Record cursor position before decoding so we can advance past the full
+    // page body regardless of how the decoders advance the cursor internally.
+    const pageEnd = cursor.offset + pageHeader.compressed_page_size;
+
     const pageData: ParquetReadData =
       pageType === 'DATA_PAGE_V2'
         ? decodeDataPageV2(cursor, pageHeader, column, compression)
         : decodeDataPage(cursor, pageHeader, column, compression);
+
+    // For UNCOMPRESSED data, decoders advance cursor.offset as they read;
+    // for COMPRESSED data, decodeDataPage/V2 already sets cursor.offset = cursorEnd.
+    // In either case, ensure we are positioned at the start of the next page.
+    cursor.offset = pageEnd;
 
     rLevelPages.push(pageData.rLevels);
     dLevelPages.push(pageData.dLevels);

--- a/test/bufferWriter.ts
+++ b/test/bufferWriter.ts
@@ -116,5 +116,97 @@ describe('ParquetBufferWriter', function () {
       const rows = [...reader];
       assert.deepEqual(rows, expectedRows);
     });
+
+    it('should round-trip correctly with useDataPageV2 enabled', function () {
+      const numRows = 50;
+      const writer = parquet.ParquetBufferWriter.openBuffer<TestRow>(testSchema, {
+        rowGroupSize: 10,
+        useDataPageV2: true,
+      });
+
+      const expectedRows: TestRow[] = [];
+      for (let i = 0; i < numRows; i++) {
+        const row = { name: `row${i}`, value: i * 100 };
+        expectedRows.push(row);
+        writer.appendRow(row);
+      }
+
+      const buf = writer.toBuffer();
+
+      const reader = parquet.ParquetBufferReader.openBuffer<TestRow>(buf);
+      assert.equal(reader.getRowCount(), numRows);
+
+      const rows = [...reader];
+      assert.deepEqual(rows, expectedRows);
+    });
+
+    it('should round-trip correctly with small pageSize forcing multiple pages', function () {
+      const numRows = 20;
+      const writer = parquet.ParquetBufferWriter.openBuffer<TestRow>(testSchema, {
+        rowGroupSize: 20,
+        pageSize: 3,
+      });
+
+      const expectedRows: TestRow[] = [];
+      for (let i = 0; i < numRows; i++) {
+        const row = { name: `row${i}`, value: i };
+        expectedRows.push(row);
+        writer.appendRow(row);
+      }
+
+      const buf = writer.toBuffer();
+      const reader = parquet.ParquetBufferReader.openBuffer<TestRow>(buf);
+      assert.equal(reader.getRowCount(), numRows);
+      assert.deepEqual([...reader], expectedRows);
+    });
+
+    it('should round-trip repeated field rows with small pageSize', function () {
+      const schema = new parquet.ParquetSchema({
+        name: { type: 'UTF8' },
+        tags: { type: 'UTF8', repeated: true },
+      });
+      interface RepRow { name: string; tags?: string[]; }
+      const rows: RepRow[] = [
+        { name: 'a', tags: ['x', 'y'] },
+        { name: 'b', tags: ['z'] },
+        { name: 'c', tags: ['p', 'q', 'r'] },
+        { name: 'd' },
+        { name: 'e', tags: ['s'] },
+      ];
+
+      const writer = parquet.ParquetBufferWriter.openBuffer<RepRow>(schema, {
+        rowGroupSize: 10,
+        pageSize: 2,
+      });
+      for (const row of rows) {
+        writer.appendRow(row);
+      }
+
+      const buf = writer.toBuffer();
+      const reader = parquet.ParquetBufferReader.openBuffer<RepRow>(buf);
+      assert.equal(reader.getRowCount(), rows.length);
+      const readRows = [...reader];
+      assert.deepEqual(readRows, rows);
+    });
+  });
+});
+
+describe('generateParquetBuffer', function () {
+  it('should produce the same result as ParquetBufferWriter', function () {
+    const schema = new parquet.ParquetSchema({
+      name: { type: 'UTF8' },
+      value: { type: 'INT32' },
+    });
+    const rows = [
+      { name: 'a', value: 1 },
+      { name: 'b', value: 2 },
+      { name: 'c', value: 3 },
+    ];
+
+    const buf = parquet.generateParquetBuffer(schema, rows);
+
+    const reader = parquet.ParquetBufferReader.openBuffer<{ name: string; value: number }>(buf);
+    assert.equal(reader.getRowCount(), rows.length);
+    assert.deepEqual([...reader], rows);
   });
 });


### PR DESCRIPTION
Adds the generateParquetBuffer convenience utility for synchronous in-memory Parquet generation. Fixes encodeColumnChunk to respect pageSize and row boundaries, especially for repeated fields. Fixes multi-page column reading in decodeDataPages by ensuring correct offsets, cursor advancement, and typed array alignment. Fixes typed array alignment checks in the plain codec and adds comprehensive tests for the new behavior.

#9

Plan: parquet-buffer-writer