### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create git tags and push version bump commits
+      pull-requests: write  # open/update "Version Packages" PRs
+      id-token: write       # mint OIDC token for npm trusted publishing
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -25,16 +29,13 @@ jobs:
         with:
           node-version: 24
           cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: yarn --immutable
 
       - name: Build and test
         run: yarn test
-
-      - name: Create .npmrc
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > .npmrc
 
       - name: Create Release Pull Request or Publish
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
@@ -43,5 +44,4 @@ jobs:
           version: yarn changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,10 @@ publishing to npm.
 
 ## Prerequisites (one-time setup)
 
-- `NPM_TOKEN` secret must be set in **GitHub → Settings → Secrets and variables
-  → Actions** with publish rights to `@dobesv/parquets`.
+- npm Trusted Publishing must be configured on the package. Go to
+  **npmjs.com → @dobesv/parquets → Settings → Publishing** and add a trusted
+  publisher pointing to `dobesv/parquets` / workflow `release.yml`. This allows
+  GitHub Actions to publish without a stored `NPM_TOKEN` secret.
 - The `github-actions` branch (or whichever branch contains the CI/CD setup)
   must be merged into `master`.
 
@@ -120,8 +122,12 @@ git push --follow-tags
   `yarn changeset status` to check).
 
 **Publish step fails with 403 / authentication error**
-- Verify the `NPM_TOKEN` secret is set and the token has `Automation` type with
-  publish access to the `@dobesv` scope.
+- Verify Trusted Publishing is configured on npmjs.com for this repo and the
+  `release.yml` workflow file name matches exactly.
+- Check that the job has `permissions: id-token: write` (it does by default in
+  this workflow).
+- Trusted Publishing requires the publish to come from the exact workflow file
+  registered — renaming the file will break it.
 
 **Build fails before publish**
 - The release workflow runs `yarn test` before publishing. Fix the failing


### PR DESCRIPTION
Remove NPM_TOKEN secret dependency. Use setup-node registry-url and id-token: write permission so GitHub mints a short-lived OIDC token at publish time instead of relying on a stored long-lived npm token.

Also add explicit permissions block (contents/pull-requests/id-token) and update RELEASING.md to reflect the new setup.